### PR TITLE
Add FastUtilWrapper basic test

### DIFF
--- a/src/test/java/org/example/firstprogram/FastUtilWrapperTest.java
+++ b/src/test/java/org/example/firstprogram/FastUtilWrapperTest.java
@@ -1,0 +1,20 @@
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+
+import it.unimi.dsi.fastutil.doubles.Double2DoubleArrayMap;
+import org.example.firstprogram.FastUtilWrapper;
+import org.junit.jupiter.api.Test;
+
+public class FastUtilWrapperTest {
+    @Test
+    void newlyCreatedWrapperHasEmptyMap() throws Exception {
+        FastUtilWrapper wrapper = new FastUtilWrapper();
+
+        Field mapField = FastUtilWrapper.class.getDeclaredField("map");
+        mapField.setAccessible(true);
+        Double2DoubleArrayMap map = (Double2DoubleArrayMap) mapField.get(wrapper);
+
+        assertTrue(map.isEmpty(), "Wrapped map should start empty");
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple JUnit 5 test for `FastUtilWrapper`

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_684bdccc1684832d89377f4ba2c86bbd